### PR TITLE
Support K8s v1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # azure-iot-edge-device-container
-[![Docker Build Status](https://dockerbuildbadges.quelltext.eu/status.svg?organization=toolboc&repository=azure-iot-edge-device-container)](https://hub.docker.com/r/toolboc/azure-iot-edge-device-container/builds) [![Docker Pulls](https://img.shields.io/docker/pulls/toolboc/azure-iot-edge-device-container.svg?style=flat-square)](https://hub.docker.com/r/toolboc/azure-iot-edge-device-container/)
+[![Docker Build Status](https://img.shields.io/docker/build/toolboc/azure-iot-edge-device-container)](https://hub.docker.com/r/toolboc/azure-iot-edge-device-container/builds/) [![Docker Pulls](https://img.shields.io/docker/pulls/toolboc/azure-iot-edge-device-container.svg?style=flat-square)](https://hub.docker.com/r/toolboc/azure-iot-edge-device-container/)
 
 An Azure IoT Edge Device in a Docker container with x64 / arm32 / aarch64 support
 


### PR DESCRIPTION
v1beta* is deprecated in v1.16:
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

This PR brings latest updates from master into the gh-pages branch